### PR TITLE
Getting an email with user profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /target
 /.idea
 /spring-social-bitbucket.iml
+rebel.xml

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>
+    </profiles>
     <build>
         <plugins>
             <plugin>
@@ -201,7 +212,7 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <additionalparam>${javadoc.opts}</additionalparam>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -104,17 +104,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.4.1</version>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.4.1.1</version>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.4.1</version>
+            <version>2.5.4</version>
         </dependency>
 
         <dependency>
@@ -147,17 +147,17 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>18.0</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1.3</version>
+            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>2.0.3</version>
+            <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -200,10 +200,14 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.1</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Low</threshold>
@@ -220,6 +224,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.15</version>
                 <configuration>
                     <suppressionsLocation>src/etc/checkstyle-suppressions.xml</suppressionsLocation>
                     <maxAllowedViolations>8</maxAllowedViolations>

--- a/src/main/java/org/springframework/social/bitbucket/api/BitBucketEmailAddress.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/BitBucketEmailAddress.java
@@ -15,37 +15,40 @@
  */
 package org.springframework.social.bitbucket.api;
 
-import org.springframework.social.ApiBinding;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
 
 /**
- * Main interface for interacting with BitBucket.
+ * BitBucket email address structure
  *
- * @author ericbottard
+ * @author Cyprian Śniegota
+ * @since 2.0.0
  */
-public interface BitBucket extends ApiBinding {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class BitBucketEmailAddress implements Serializable {
 
-    /**
-     * Returns the portion of the BitBucket API that allow interaction with
-     * repositories.
-     */
-    RepoOperations repoOperations();
+    private static final long serialVersionUID = 1L;
 
-    /**
-     * Returns the portion of the BitBucket API that allow interaction with user
-     * accounts.
-     */
-    UserOperations userOperations();
+    @JsonProperty("active")
+    private Boolean active;
 
-    /**
-     * Returns the portion of the BitBucket API that allow messing with
-     * privileges.
-     */
-    PrivilegeOperations privelegesOperations();
+    @JsonProperty("email")
+    private String email;
 
-    /**
-     * Users managemet API
-     *
-     * @return users management API
-     */
-    UsersOperations usersOperations();
+    @JsonProperty("primary")
+    private Boolean primary;
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Boolean getPrimary() {
+        return primary;
+    }
 }

--- a/src/main/java/org/springframework/social/bitbucket/api/EmailsOperations.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/EmailsOperations.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2012 Eric Bottard / Guillaume Lederrey (eric.bottard+ghpublic@gmail.com / guillaume.lederrey@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.bitbucket.api;
+
+import java.util.List;
+
+/**
+ * emails Resource
+ * @see "https://confluence.atlassian.com/display/BITBUCKET/emails+Resource"
+ *
+ * @author Cyprian Śniegota
+ * @since 2.0.0
+ */
+public interface EmailsOperations {
+
+    /**
+     * Gets the email addresses associated with the account.
+     *
+     * @param accountName The name of an individual or team account.
+     * @return list of email addresses
+     */
+    List<BitBucketEmailAddress> getListOfUserEmailAddresses(String accountName);
+
+    /**
+     * Gets an individual email address associated with an account.
+     *
+     * @param accountName The name of an individual or team account.
+     * @param emailAddress The email address to get.
+     * @return email address
+     */
+    BitBucketEmailAddress getAnEmailAddress(String accountName, String emailAddress);
+
+    /**
+     * Adds additional email addresses to an account.
+     *
+     * @param accountName The name of an individual or team account.
+     * @param emailAddress The email address to post.
+     * @return list of email addresses
+     */
+    List<BitBucketEmailAddress> postANewEmailAddress(String accountName, String emailAddress);
+
+    /**
+     * Sets an individual email address associated with an account to primary.
+     * The primary email address is the main email contact for the account.
+     * Only a single address on an account can be primary.
+     * If another address had primary set prior to this call, after it is no longer primary.
+     *
+     * @param accountName The name of an individual or team account.
+     * @param emailAddress The email address to modify.
+     * @return modified email address
+     */
+    BitBucketEmailAddress updateAnEmailAddress(String accountName, String emailAddress);
+
+}

--- a/src/main/java/org/springframework/social/bitbucket/api/UsersOperations.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/UsersOperations.java
@@ -15,37 +15,20 @@
  */
 package org.springframework.social.bitbucket.api;
 
-import org.springframework.social.ApiBinding;
-
 /**
- * Main interface for interacting with BitBucket.
+ * The /users endpoints gets information related to an individual or team account.
+ * Aggregates users operations
+ * https://confluence.atlassian.com/display/BITBUCKET/users+Endpoint+-+1.0
  *
- * @author ericbottard
+ * @author Cyprian Śniegota
+ * @since 2.0.0
  */
-public interface BitBucket extends ApiBinding {
+public interface UsersOperations {
 
     /**
-     * Returns the portion of the BitBucket API that allow interaction with
-     * repositories.
-     */
-    RepoOperations repoOperations();
-
-    /**
-     * Returns the portion of the BitBucket API that allow interaction with user
-     * accounts.
-     */
-    UserOperations userOperations();
-
-    /**
-     * Returns the portion of the BitBucket API that allow messing with
-     * privileges.
-     */
-    PrivilegeOperations privelegesOperations();
-
-    /**
-     * Users managemet API
+     * Emails managemet API
      *
-     * @return users management API
+     * @return emails management API template
      */
-    UsersOperations usersOperations();
+    EmailsOperations emailsOperations();
 }

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java
@@ -15,10 +15,7 @@
  */
 package org.springframework.social.bitbucket.api.impl;
 
-import org.springframework.social.bitbucket.api.BitBucket;
-import org.springframework.social.bitbucket.api.PrivilegeOperations;
-import org.springframework.social.bitbucket.api.RepoOperations;
-import org.springframework.social.bitbucket.api.UserOperations;
+import org.springframework.social.bitbucket.api.*;
 import org.springframework.social.oauth1.AbstractOAuth1ApiBinding;
 
 public class BitBucketTemplate extends AbstractOAuth1ApiBinding implements
@@ -29,6 +26,8 @@ public class BitBucketTemplate extends AbstractOAuth1ApiBinding implements
     private RepoOperations repoOperations;
 
     private PrivilegeOperations privilegeOperations;
+
+    private UsersOperations usersOperations;
 
     public BitBucketTemplate(String consumerKey, String consumerSecret,
                              String accessToken, String accessTokenSecret) {
@@ -46,6 +45,7 @@ public class BitBucketTemplate extends AbstractOAuth1ApiBinding implements
         repoOperations = new RepoTemplate(getRestTemplate(), isAuthorized());
         privilegeOperations = new PrivilegeTemplate(getRestTemplate(),
                 isAuthorized());
+        usersOperations = new UsersTemplate(getRestTemplate(), isAuthorized());
     }
 
     @Override
@@ -63,4 +63,8 @@ public class BitBucketTemplate extends AbstractOAuth1ApiBinding implements
         return privilegeOperations;
     }
 
+    @Override
+    public final UsersOperations usersOperations() {
+        return usersOperations;
+    }
 }

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/EmailsTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/EmailsTemplate.java
@@ -19,8 +19,9 @@ import org.springframework.social.bitbucket.api.BitBucketEmailAddress;
 import org.springframework.social.bitbucket.api.EmailsOperations;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Arrays;
 import java.util.List;
+
+import static java.util.Arrays.asList;
 
 /**
  * @author Cyprian Śniegota
@@ -34,7 +35,7 @@ public class EmailsTemplate extends AbstractBitBucketOperations implements Email
 
     @Override
     public final List<BitBucketEmailAddress> getListOfUserEmailAddresses(String accountName) {
-        return Arrays.asList(getRestTemplate().getForObject(buildUrl("/users/{accountname}/emails"),
+        return asList(getRestTemplate().getForObject(buildUrl("/users/{accountname}/emails"),
                 BitBucketEmailAddress[].class, accountName));
     }
 

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/EmailsTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/EmailsTemplate.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2012 Eric Bottard / Guillaume Lederrey (eric.bottard+ghpublic@gmail.com / guillaume.lederrey@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.bitbucket.api.impl;
+
+import org.springframework.social.bitbucket.api.BitBucketEmailAddress;
+import org.springframework.social.bitbucket.api.EmailsOperations;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Cyprian Śniegota
+ * @since 2.0.0
+ */
+public class EmailsTemplate extends AbstractBitBucketOperations implements EmailsOperations {
+
+    public EmailsTemplate(RestTemplate restTemplate, boolean authorized) {
+        super(restTemplate, authorized, V1);
+    }
+
+    @Override
+    public final List<BitBucketEmailAddress> getListOfUserEmailAddresses(String accountName) {
+        return Arrays.asList(getRestTemplate().getForObject(buildUrl("/users/{accountname}/emails"),
+                BitBucketEmailAddress[].class, accountName));
+    }
+
+    @Override
+    public final BitBucketEmailAddress getAnEmailAddress(String accountName, String emailAddress) {
+        return getRestTemplate().getForObject(buildUrl("/users/{accountname}/emails/{email_address}"),
+                BitBucketEmailAddress.class, accountName, emailAddress);
+    }
+
+    @Override
+    public final List<BitBucketEmailAddress> postANewEmailAddress(String accountName, String emailAddress) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public final BitBucketEmailAddress updateAnEmailAddress(String accountName, String emailAddress) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/UsersTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/UsersTemplate.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2012 Eric Bottard / Guillaume Lederrey (eric.bottard+ghpublic@gmail.com / guillaume.lederrey@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.bitbucket.api.impl;
+
+import org.springframework.social.bitbucket.api.EmailsOperations;
+import org.springframework.social.bitbucket.api.UsersOperations;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author Cyprian Śniegota
+ * @since 2.0.0
+ */
+public class UsersTemplate extends AbstractBitBucketOperations implements UsersOperations {
+
+    private final EmailsOperations emailsOperations;
+
+    public UsersTemplate(RestTemplate restTemplate, boolean authorized) {
+        super(restTemplate, authorized, V1);
+        emailsOperations = new EmailsTemplate(getRestTemplate(), isAuthorized());
+    }
+    @Override
+    public final EmailsOperations emailsOperations() {
+        return emailsOperations;
+    }
+}

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/UsersTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/UsersTemplate.java
@@ -31,6 +31,7 @@ public class UsersTemplate extends AbstractBitBucketOperations implements UsersO
         super(restTemplate, authorized, V1);
         emailsOperations = new EmailsTemplate(getRestTemplate(), isAuthorized());
     }
+
     @Override
     public final EmailsOperations emailsOperations() {
         return emailsOperations;

--- a/src/main/java/org/springframework/social/bitbucket/config/support/BitBucketApiHelper.java
+++ b/src/main/java/org/springframework/social/bitbucket/config/support/BitBucketApiHelper.java
@@ -29,7 +29,7 @@ import org.springframework.social.connect.UsersConnectionRepository;
  *
  * @author Eric Bottard
  */
-public class BitBucketApiHelper implements ApiHelper<BitBucket> {
+public final class BitBucketApiHelper implements ApiHelper<BitBucket> {
     private final UsersConnectionRepository usersConnectionRepository;
 
     private final UserIdSource userIdSource;
@@ -57,6 +57,5 @@ public class BitBucketApiHelper implements ApiHelper<BitBucket> {
         return connection.getApi();
     }
 
-    private static final Log logger = LogFactory
-            .getLog(BitBucketApiHelper.class);
+    private final Log logger = LogFactory.getLog(BitBucketApiHelper.class);
 }

--- a/src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java
+++ b/src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 public class BitBucketAdapter implements ApiAdapter<BitBucket> {
 
-    private static final Log logger = LogFactory.getLog(BitBucketAdapter.class);
+    private final Log logger = LogFactory.getLog(BitBucketAdapter.class);
 
     @Override
     public final boolean test(BitBucket api) {
@@ -76,9 +76,9 @@ public class BitBucketAdapter implements ApiAdapter<BitBucket> {
                 throw clientError;
             } else {
                 if (logger.isWarnEnabled()) {
-                    logger.warn("BitBucket consumer configuration: Permissions:Acount:Email is not granted." +
-                            " Email property will be set to 'null' in UserProfile" +
-                            " [username:'" + user.getUsername() + "']");
+                    logger.warn("BitBucket consumer configuration: Permissions:Acount:Email is not granted."
+                            + " Email property will be set to 'null' in UserProfile"
+                            + " [username:'" + user.getUsername() + "']");
                 }
             }
         }

--- a/src/test/java/org/springframework/social/bitbucket/api/impl/EmailsTemplateTest.java
+++ b/src/test/java/org/springframework/social/bitbucket/api/impl/EmailsTemplateTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2012 Eric Bottard / Guillaume Lederrey (eric.bottard+ghpublic@gmail.com / guillaume.lederrey@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.bitbucket.api.impl;
+
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.social.bitbucket.api.BitBucketEmailAddress;
+import org.springframework.social.bitbucket.api.BitBucketRepository;
+import org.springframework.social.bitbucket.api.BitBucketSCM;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * @author Cyprian Śniegota
+ * @since 2.0.0
+ */
+public class EmailsTemplateTest extends BaseTemplateTest {
+
+    @Test
+    public void testGetListOfUserEmailAddresses() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/users/sampleuser/emails"))
+                .andExpect(method(GET)).andRespond(withSuccess(jsonResource("get-list-of-users-email-addresses"),
+                MediaType.APPLICATION_JSON));
+        //when
+        List<BitBucketEmailAddress> listOfUserEmailAddresses = bitBucket.usersOperations().emailsOperations()
+                .getListOfUserEmailAddresses("sampleuser");
+        //then
+        assertEquals(2, listOfUserEmailAddresses.size());
+        BitBucketEmailAddress firstEmailAddress = listOfUserEmailAddresses.iterator().next();
+        assertEquals("2team.bb@gmail.com", firstEmailAddress.getEmail());
+        assertEquals(true, firstEmailAddress.getActive());
+        assertEquals(true, firstEmailAddress.getPrimary());
+    }
+
+    @Test
+    public void testGetAnEmailAddress() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/users/sampleuser/emails/ourteam@gmail.com"))
+                .andExpect(method(GET)).andRespond(withSuccess(jsonResource("get-an-email-address"),
+                MediaType.APPLICATION_JSON));
+        //when
+        BitBucketEmailAddress sampleuser = bitBucket.usersOperations().emailsOperations()
+                .getAnEmailAddress("sampleuser", "ourteam@gmail.com");
+        //then
+        assertEquals("ourteam@gmail.com", sampleuser.getEmail());
+        assertEquals(false, sampleuser.getActive());
+        assertEquals(false, sampleuser.getPrimary());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testPostANewEmailAddress() throws Exception {
+        //given
+        //when
+        bitBucket.usersOperations().emailsOperations().postANewEmailAddress("sampleuser", "ourteam@gmail.com");
+        //then
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateAnEmailAddress() throws Exception {
+        //given
+        //when
+        bitBucket.usersOperations().emailsOperations().updateAnEmailAddress("sampleuser", "ourteam@gmail.com");
+        //then
+    }
+}

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/get-an-email-address.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/get-an-email-address.json
@@ -1,0 +1,5 @@
+{
+  "active": false,
+  "email": "ourteam@gmail.com",
+  "primary": false
+}

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/get-list-of-users-email-addresses.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/get-list-of-users-email-addresses.json
@@ -1,0 +1,12 @@
+[
+  {
+    "active": true,
+    "email": "2team.bb@gmail.com",
+    "primary": true
+  },
+  {
+    "active": false,
+    "email": "ourteam@gmail.com",
+    "primary": false
+  }
+]


### PR DESCRIPTION
Partial implementation of
https://confluence.atlassian.com/display/BITBUCKET/emails+Resource
with API tree (users->emails) as written in documentation
+ update profile with user's email
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382135%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382157%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382186%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382208%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382255%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382953%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383304%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383343%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383471%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383483%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383484%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383509%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383516%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383517%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20ffa89d33d475f6141f47629ac464ea19c23f0fc4%20src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382186%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20that%20all%20those%20%60%2AOperations%60%20could%20actually%20be%20final.%20That%20would%20require%20to%20inline%20%60initSubApis%28%29%60%20but%20it%20is%20probably%20worth%20it.%20%28Again%2C%20not%20directly%20related%20to%20your%20PR%2C%20feel%20free%20to%20ignore%29.%22%2C%20%22created_at%22%3A%20%222015-06-14T17%3A46%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-14T19%3A46%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java%3AL27-35%22%7D%2C%20%22Pull%2018fccb2248429253188e03c1e397932c2e837f1c%20src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32383509%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20was%20going%20to%20suggest%20to%20add%20a%20comment%20explaining%20your%20intention%2C%20but%20the%20log%20message%20makes%20that%20clear.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-14T19%3A48%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java%3AL55-91%22%7D%2C%20%22Pull%20ffa89d33d475f6141f47629ac464ea19c23f0fc4%20src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382255%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20a%20reason%20to%20ignore%20other%20HTTP%20errors%3F%20I%20would%20prefer%20to%20let%20the%20exceptions%20bubble%20up.%20The%20client%20of%20that%20API%20probably%20expect%20the%20full%20profile%20to%20be%20loaded%20by%20this%20method.%20At%20least%20we%20should%20log%20a%20warning%20for%20exceptions%20that%20are%20hidden.%22%2C%20%22created_at%22%3A%20%222015-06-14T17%3A51%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22if%20Permissions%3AAcount%3AEmail%20is%20not%20set%2C%20then%20email%20property%20is%20not%20expected%20in%20UserProfile%20by%20client%20%28bitbucket%20will%20answer%20with%20403%29.%20Every%20other%20error%20will%20be%20pushed%20up.%20Warning%20implemented.%22%2C%20%22created_at%22%3A%20%222015-06-14T19%3A27%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11454677%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyprianno%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-14T19%3A49%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java%3AL51-74%22%7D%2C%20%22Pull%20ffa89d33d475f6141f47629ac464ea19c23f0fc4%20src/main/java/org/springframework/social/bitbucket/api/impl/EmailsTemplate.java%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382208%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20add%20a%20static%20import%20for%20%60Arrays.asList%28%29%60.%20%28minor%20comment%2C%20feel%20free%20to%20ignore%29.%22%2C%20%22created_at%22%3A%20%222015-06-14T17%3A47%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-06-14T19%3A23%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11454677%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyprianno%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-14T19%3A49%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/api/impl/EmailsTemplate.java%3AL1-57%22%7D%2C%20%22Pull%20ffa89d33d475f6141f47629ac464ea19c23f0fc4%20src/main/java/org/springframework/social/bitbucket/api/BitBucketEmailAddress.java%2043%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382157%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Side%20note%20%28not%20related%20to%20your%20PR%2C%20feel%20free%20to%20ignore%29%3A%20we%20should%20introduce%20Lombok%20for%20generating%20getters%20and%20setters.%22%2C%20%22created_at%22%3A%20%222015-06-14T17%3A44%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-14T19%3A46%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/api/BitBucketEmailAddress.java%3AL1-55%22%7D%2C%20%22Pull%20ffa89d33d475f6141f47629ac464ea19c23f0fc4%20pom.xml%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/12%23discussion_r32382135%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20probably%20go%20to%20a%20profile%2C%20activated%20for%20JDK8.%22%2C%20%22created_at%22%3A%20%222015-06-14T17%3A42%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-06-14T18%3A53%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11454677%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyprianno%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-14T19%3A44%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL200-214%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull ffa89d33d475f6141f47629ac464ea19c23f0fc4 pom.xml 46'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/12#discussion_r32382135'>File: pom.xml:L200-214</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This should probably go to a profile, activated for JDK8.
- <a href='https://github.com/cyprianno'><img border=0 src='https://avatars.githubusercontent.com/u/11454677?v=3' height=16 width=16'></a> fixed
- [x] <a href='#crh-comment-Pull ffa89d33d475f6141f47629ac464ea19c23f0fc4 src/main/java/org/springframework/social/bitbucket/api/BitBucketEmailAddress.java 43'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/12#discussion_r32382157'>File: src/main/java/org/springframework/social/bitbucket/api/BitBucketEmailAddress.java:L1-55</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Side note (not related to your PR, feel free to ignore): we should introduce Lombok for generating getters and setters.
- [x] <a href='#crh-comment-Pull ffa89d33d475f6141f47629ac464ea19c23f0fc4 src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/12#discussion_r32382186'>File: src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java:L27-35</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems that all those `*Operations` could actually be final. That would require to inline `initSubApis()` but it is probably worth it. (Again, not directly related to your PR, feel free to ignore).
- [x] <a href='#crh-comment-Pull ffa89d33d475f6141f47629ac464ea19c23f0fc4 src/main/java/org/springframework/social/bitbucket/api/impl/EmailsTemplate.java 37'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/12#discussion_r32382208'>File: src/main/java/org/springframework/social/bitbucket/api/impl/EmailsTemplate.java:L1-57</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I would add a static import for `Arrays.asList()`. (minor comment, feel free to ignore).
- <a href='https://github.com/cyprianno'><img border=0 src='https://avatars.githubusercontent.com/u/11454677?v=3' height=16 width=16'></a> fixed
- [x] <a href='#crh-comment-Pull ffa89d33d475f6141f47629ac464ea19c23f0fc4 src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java 36'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/12#discussion_r32382255'>File: src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java:L51-74</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Is there a reason to ignore other HTTP errors? I would prefer to let the exceptions bubble up. The client of that API probably expect the full profile to be loaded by this method. At least we should log a warning for exceptions that are hidden.
- <a href='https://github.com/cyprianno'><img border=0 src='https://avatars.githubusercontent.com/u/11454677?v=3' height=16 width=16'></a> if Permissions:Acount:Email is not set, then email property is not expected in UserProfile by client (bitbucket will answer with 403). Every other error will be pushed up. Warning implemented.
- [x] <a href='#crh-comment-Pull 18fccb2248429253188e03c1e397932c2e837f1c src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java 54'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/12#discussion_r32383509'>File: src/main/java/org/springframework/social/bitbucket/connect/BitBucketAdapter.java:L55-91</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I was going to suggest to add a comment explaining your intention, but the log message makes that clear. :+1:


<a href='https://www.codereviewhub.com/gehel/spring-social-bitbucket/pull/12?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/gehel/spring-social-bitbucket/pull/12?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/gehel/spring-social-bitbucket/pull/12'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>