### PR TITLE
API coverage update: privileges, groups

### DIFF
--- a/src/main/java/org/springframework/social/bitbucket/api/BitBucket.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/BitBucket.java
@@ -31,6 +31,13 @@ public interface BitBucket extends ApiBinding {
     RepoOperations repoOperations();
 
     /**
+     * Groups management operations
+     *
+     * @return groups management API
+     */
+    GroupsOperations groupsOperations();
+
+    /**
      * Returns the portion of the BitBucket API that allow interaction with user
      * accounts.
      */

--- a/src/main/java/org/springframework/social/bitbucket/api/BitBucketEmailAddress.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/BitBucketEmailAddress.java
@@ -32,15 +32,15 @@ public final class BitBucketEmailAddress implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @JsonProperty("active")
-    private Boolean active;
+    private boolean active;
 
     @JsonProperty("email")
     private String email;
 
     @JsonProperty("primary")
-    private Boolean primary;
+    private boolean primary;
 
-    public Boolean getActive() {
+    public boolean getActive() {
         return active;
     }
 
@@ -48,7 +48,7 @@ public final class BitBucketEmailAddress implements Serializable {
         return email;
     }
 
-    public Boolean getPrimary() {
+    public boolean getPrimary() {
         return primary;
     }
 }

--- a/src/main/java/org/springframework/social/bitbucket/api/BitBucketGroup.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/BitBucketGroup.java
@@ -19,50 +19,56 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * A BitBucket user account.
- *
- * @author Eric Bottard
+ * @author Cyprian Śniegota
+ * @since 2.0.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class BitBucketUser implements Serializable {
-
+public class BitBucketGroup implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @JsonProperty
-    private String username;
+    private String name;
 
-    @JsonProperty("first_name")
-    private String firstName;
+    @JsonProperty
+    private BitBucketPrivilege permission;
 
-    @JsonProperty("last_name")
-    private String lastName;
+    @JsonProperty("auto_add")
+    private boolean autoAdd;
 
-    @JsonProperty("is_team")
-    private boolean team;
+    @JsonProperty
+    private String slug;
 
-    @JsonProperty("avatar")
-    private String avatarImageUrl;
+    @JsonProperty
+    private List<BitBucketUser> members = new ArrayList<>();
 
-    public final String getUsername() {
-        return username;
+    @JsonProperty
+    private BitBucketUser owner;
+
+    public final String getName() {
+        return name;
     }
 
-    public final String getFirstName() {
-        return firstName;
+    public final BitBucketPrivilege getPermission() {
+        return permission;
     }
 
-    public final String getLastName() {
-        return lastName;
+    public final boolean isAutoAdd() {
+        return autoAdd;
     }
 
-    public final boolean isTeam() {
-        return team;
+    public final String getSlug() {
+        return slug;
     }
 
-    public final String getAvatarImageUrl() {
-        return avatarImageUrl;
+    public final List<BitBucketUser> getMembers() {
+        return members;
     }
 
+    public final BitBucketUser getOwner() {
+        return owner;
+    }
 }

--- a/src/main/java/org/springframework/social/bitbucket/api/BitBucketGroup.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/BitBucketGroup.java
@@ -17,6 +17,7 @@ package org.springframework.social.bitbucket.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -30,45 +31,22 @@ import java.util.List;
 public class BitBucketGroup implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    @JsonProperty
+    @JsonProperty @Getter
     private String name;
 
-    @JsonProperty
+    @JsonProperty @Getter
     private BitBucketPrivilege permission;
 
-    @JsonProperty("auto_add")
+    @JsonProperty("auto_add") @Getter
     private boolean autoAdd;
 
-    @JsonProperty
+    @JsonProperty @Getter
     private String slug;
 
-    @JsonProperty
+    @JsonProperty @Getter
     private List<BitBucketUser> members = new ArrayList<>();
 
-    @JsonProperty
+    @JsonProperty @Getter
     private BitBucketUser owner;
 
-    public final String getName() {
-        return name;
-    }
-
-    public final BitBucketPrivilege getPermission() {
-        return permission;
-    }
-
-    public final boolean isAutoAdd() {
-        return autoAdd;
-    }
-
-    public final String getSlug() {
-        return slug;
-    }
-
-    public final List<BitBucketUser> getMembers() {
-        return members;
-    }
-
-    public final BitBucketUser getOwner() {
-        return owner;
-    }
 }

--- a/src/main/java/org/springframework/social/bitbucket/api/BitBucketUser.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/BitBucketUser.java
@@ -43,7 +43,7 @@ public class BitBucketUser implements Serializable {
     @JsonProperty("is_team") @Getter
     private boolean team;
 
-    @JsonProperty("avatar")
+    @JsonProperty("avatar") @Getter
     private String avatarImageUrl;
 
 }

--- a/src/main/java/org/springframework/social/bitbucket/api/GroupsOperations.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/GroupsOperations.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2012 Eric Bottard / Guillaume Lederrey (eric.bottard+ghpublic@gmail.com / guillaume.lederrey@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.bitbucket.api;
+
+import java.util.List;
+
+/**
+ * The groups endpoint provides functionality for querying information about groups,
+ * creating new ones, updating memberships, and deleting them.
+ * Both individual and team accounts can define groups.
+ * To manage group information on an individual account,
+ * the caller must authenticate with administrative rights on the account.
+ * To manage groups for a team account, the caller must authenticate as a team member
+ * with administrative rights on the team.
+ *
+ * @see "https://confluence.atlassian.com/display/BITBUCKET/groups+Endpoint"
+ * @author Cyprian Śniegota
+ * @since 2.0.0
+ */
+public interface GroupsOperations {
+
+    /**
+     * Get a list of an account's groups.  The caller must authenticate with administrative rights on the account or as a group member to view a group.
+     * GET https://bitbucket.org/api/1.0/groups/{accountname}/
+     *
+     * @param accountName The team or individual account name. You can supply a user name or a valid email address.
+     * @return list of groups
+     */
+    List<BitBucketGroup> getAListOfGroups(String accountName);
+
+    /**
+     * Creates a new group.  The caller must authenticate with administrative rights on an account to access its groups.
+     * POST https://bitbucket.org/api/1.0/groups/{accountname}  --data "name=string"
+     *
+     * @param accountName The team or individual account name. You can supply a user name or a valid email address.
+     * @param name The name of the group.
+     * @return newly created group
+     */
+    BitBucketGroup postANewGroup(String accountName, String name);
+
+    /**
+     * Updates an existing group resource. The caller must authenticate with administrative rights on the account.
+     * PUT https://bitbucket.org/api/1.0/groups/{accountname}/{group_slug}/  --header "Accept: application/json"
+     * --data '{"name":"developers","permission":"write","auto_add":true}'
+     *
+     * @param accountName The team or individual account name. You can supply an account name or the primary email address for the account.
+     * @param name The name of the group.
+     * @param groupSlug The group's slug.
+     * @param autAdd A boolean value. True to automatically add the group
+     * @param permission One of read, write, or admin.
+     * @return updated group
+     */
+    BitBucketGroup updateAGroup(String accountName, String name, String groupSlug, Boolean autAdd, BitBucketPrivilege permission);
+
+    /**
+     * Deletes a group.  The caller must authenticate with administrative rights on the account.
+     * DELETE  https://bitbucket.org/api/1.0/groups/{accountname}/{group_slug}/
+     *
+     * @param accountName The team or individual account name. You can supply an account name or the primary email address for the account.
+     * @param groupSlug The group's slug.
+     */
+    void removeGroup(String accountName, String groupSlug);
+
+    /**
+     * Gets the membership for a group. The caller must authenticate with administrative rights on the account.
+     * GET https://bitbucket.org/api/1.0/groups/{accountname}/{group_slug}/members
+     *
+     * @param accountName The team or individual account name. You can supply an account name or the primary email address for the account.
+     * @param groupSlug The group's slug.
+     * @return list of group members
+     */
+    List<BitBucketUser> getTheGroupMembers(String accountName, String groupSlug);
+
+    /**
+     * Adds a member to a group. Finally, the caller must authenticate with administrative rights on an account to access its groups.
+     * PUT https://bitbucket.org/api/1.0/groups/{accountname}/{group_slug}/members/{membername}
+     *
+     * @param accountName The team or individual account name. You can supply an account name or the primary email address for the account.
+     * @param groupSlug The slug of the group.
+     * @param memberName An individual account. You can supply an account name or the primary email address for the account. Account names are case sensitive.
+     * @return member data
+     */
+    BitBucketUser putNewMemberIntoAGroup(String accountName, String groupSlug, String memberName);
+
+    /**
+     * Deletes a member from a group.  The caller must authenticate with administrative rights on the account.
+     * DELETE  https://bitbucket.org/api/1.0/groups/{accountname}/{group_slug}/members/{membername}
+     *
+     * @param accountName The team or individual account name. You can supply an account name or the primary email address for the account.
+     * @param groupSlug The group's slug.
+     * @param memberName A individual account name. You can supply an account name or the primary email address for the account.
+     */
+    void removeMember(String accountName, String groupSlug, String memberName);
+
+
+}

--- a/src/main/java/org/springframework/social/bitbucket/api/PrivilegeOperations.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/PrivilegeOperations.java
@@ -21,31 +21,75 @@ public interface PrivilegeOperations {
 
     /**
      * Get the privileges on a given repository.
+     * GET https://bitbucket.org/api/1.0/privileges/{accountname}/{repo_slug}
      *
-     * @param user     repository owner
+     * @param accountName     repository owner
      * @param repoSlug name of the repository
      */
-    List<RepoPrivilege> getRepoPrivileges(String user, String repoSlug);
+    List<RepoPrivilege> getRepoPrivileges(String accountName, String repoSlug);
+
+    /**
+     * Get a list of privileges for an individual account.
+     * Only the repository owner, a team account administrator, or an account with administrative rights on the repository can make this call.
+     * GET https://api.bitbucket.org/1.0/privileges/{accountname}/{repo_slug}/{privilege_account}
+     *
+     * @param accountName  username
+     * @param repoSlug repo_slug
+     * @param privilegeAccount privilege_account
+     * @return list of privileges
+     */
+    List<RepoPrivilege> getPrivilegesForAnIndividual(String accountName, String repoSlug, String privilegeAccount);
+
+    /**
+     * Gets a list of all the privilege across all an account's repositories.
+     * If a repository has no individual users with privileges, it does not appear in this list.
+     * Only the repository owner, a team account administrator, or an account with administrative rights on the repository can make this call.
+     * GET https://api.bitbucket.org/1.0/privileges/{accountname}
+     * GET https://api.bitbucket.org/1.0/privileges/{accountname}?filter={filter}
+     *
+     * @param accountName account_name
+     * @return list of privileges
+     */
+    List<RepoPrivilege> getPrivilegesAcrossAllRepositories(String accountName);
 
     /**
      * Set or change the privilege for the given recipient on some repository.
+     * PUT  https://api.bitbucket.org/1.0/privileges/{accountname}/{repo_slug}/{privilege_account} --data {read}
      *
-     * @param owner     the repository owner
+     * @param accountName     the repository owner
      * @param repoSlug  the repository name
      * @param recipient user for which to set the privilege
      * @param privilege new privilege value to set
      */
-    RepoPrivilege setPrivilege(String owner, String repoSlug,
-                               String recipient, BitBucketPrivilege privilege);
+    RepoPrivilege setPrivilege(String accountName, String repoSlug, String recipient, BitBucketPrivilege privilege);
 
     /**
      * Removes the current privilege of the given recipient from some
      * repository.
+     * DELETE  https://bitbucket.org/api/1.0/privileges/{accountname}/{repo_slug}/{privilege_account}
      *
-     * @param owner     the repository owner
+     * @param accountName     the repository owner
      * @param repoSlug  the repository name
      * @param recipient user for which to remove the privilege
      */
-    void removePrivilege(String owner, String repoSlug, String recipient);
+    void removePrivilege(String accountName, String repoSlug, String recipient);
 
+    /**
+     * Delete all privileges from a repository.
+     * Only the repository owner, a team account administrator, or an account with administrative rights on the repository can make this call.
+     * DELETE  https://bitbucket.org/api/1.0/privileges/{accountname}/{repo_slug}
+     *
+     * @param accountName Owner of the repository.
+     * @param repoSlug Repository identifier.
+     */
+    void removeAllPrivilegesFromARepository(String accountName, String repoSlug);
+
+    /**
+     * DELETE an privileges from all repositories.
+     * Only the repository owner, a team account administrator, or an account with administrative rights on the repository can make this call.
+     * DELETE  https://bitbucket.org/api/1.0/privileges/{accountname}
+     *
+     * @param accountName Owner of the repositories.
+     */
+    void removeAllPrivilegesFromAllRepositories(String accountName);
 }

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java
@@ -29,6 +29,8 @@ public class BitBucketTemplate extends AbstractOAuth1ApiBinding implements
 
     private UsersOperations usersOperations;
 
+    private GroupsOperations groupsOperations;
+
     public BitBucketTemplate(String consumerKey, String consumerSecret,
                              String accessToken, String accessTokenSecret) {
         super(consumerKey, consumerSecret, accessToken, accessTokenSecret);
@@ -46,11 +48,17 @@ public class BitBucketTemplate extends AbstractOAuth1ApiBinding implements
         privilegeOperations = new PrivilegeTemplate(getRestTemplate(),
                 isAuthorized());
         usersOperations = new UsersTemplate(getRestTemplate(), isAuthorized());
+        groupsOperations = new GroupsTemplate(getRestTemplate(), isAuthorized());
     }
 
     @Override
     public final RepoOperations repoOperations() {
         return repoOperations;
+    }
+
+    @Override
+    public final GroupsOperations groupsOperations() {
+        return groupsOperations;
     }
 
     @Override

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/GroupsTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/GroupsTemplate.java
@@ -16,6 +16,7 @@
 package org.springframework.social.bitbucket.api.impl;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -97,29 +98,17 @@ public class GroupsTemplate extends AbstractBitBucketOperations implements Group
 
     private static final class GroupUpdate {
 
-        @JsonProperty
+        @JsonProperty @Getter
         private final String name;
-        @JsonProperty
+        @JsonProperty @Getter
         private final BitBucketPrivilege permission;
-        @JsonProperty(value = "auto_add")
+        @JsonProperty(value = "auto_add") @Getter
         private final Boolean autoAdd;
 
         public GroupUpdate(String nameParam, BitBucketPrivilege permissionParam, Boolean autoAddParam) {
             this.name = nameParam;
             this.permission = permissionParam;
             this.autoAdd = autoAddParam;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public BitBucketPrivilege getPermission() {
-            return permission;
-        }
-
-        public Boolean getAutoAdd() {
-            return autoAdd;
         }
     }
 

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/GroupsTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/GroupsTemplate.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2012 Eric Bottard / Guillaume Lederrey (eric.bottard+ghpublic@gmail.com / guillaume.lederrey@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.bitbucket.api.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.social.bitbucket.api.BitBucketGroup;
+import org.springframework.social.bitbucket.api.BitBucketPrivilege;
+import org.springframework.social.bitbucket.api.BitBucketUser;
+import org.springframework.social.bitbucket.api.GroupsOperations;
+import org.springframework.social.support.ParameterMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+/**
+ * @author Cyprian Śniegota
+ * @since 2.0.0
+ */
+public class GroupsTemplate extends AbstractBitBucketOperations implements GroupsOperations {
+
+    public GroupsTemplate(RestTemplate restTemplate, boolean authorized) {
+        super(restTemplate, authorized, V1);
+    }
+
+    @Override
+    public final List<BitBucketGroup> getAListOfGroups(String accountName) {
+        return asList(getRestTemplate().getForObject(buildUrl("/groups/{accountname}"), BitBucketGroup[].class, accountName));
+    }
+
+    @Override
+    public final BitBucketGroup postANewGroup(String accountName, String name) {
+        return getRestTemplate().postForObject(buildUrl("/groups/{accountname}"), new GroupCreate(name), BitBucketGroup.class, accountName);
+    }
+
+    @Override
+    public final BitBucketGroup updateAGroup(String accountName, String name, String groupSlug, Boolean autAdd, BitBucketPrivilege permission) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<GroupUpdate> requestEntity = new HttpEntity<>(new GroupUpdate(name, permission, autAdd), httpHeaders);
+        return getRestTemplate().exchange(
+                buildUrl("/groups/{accountname}/{group_slug}"),
+                HttpMethod.PUT, requestEntity,
+                BitBucketGroup.class, accountName, groupSlug).getBody();
+    }
+
+    @Override
+    public final void removeGroup(String accountName, String groupSlug) {
+        getRestTemplate().delete(buildUrl("/groups/{accountname}/{group_slug}"), accountName, groupSlug);
+    }
+
+    @Override
+    public final List<BitBucketUser> getTheGroupMembers(String accountName, String groupSlug) {
+        return asList(getRestTemplate().getForObject(buildUrl("/groups/{accountname}/{group_slug}/members"), BitBucketUser[].class, accountName, groupSlug));
+    }
+
+    @Override
+    public final BitBucketUser putNewMemberIntoAGroup(String accountName, String groupSlug, String memberName) {
+        return getRestTemplate()
+                .exchange(buildUrl("/groups/{accountname}/{group_slug}/members/{membername}"), HttpMethod.PUT, null, BitBucketUser.class, accountName,
+                        groupSlug, memberName).getBody();
+    }
+
+    @Override
+    public final void removeMember(String accountName, String groupSlug, String memberName) {
+        getRestTemplate().delete(buildUrl("/groups/{accountname}/{group_slug}/members/{membername}"), accountName, groupSlug, memberName);
+    }
+
+    private static final class GroupCreate extends ParameterMap {
+
+        public GroupCreate(String name) {
+            set("name", name);
+        }
+
+        public String getName() {
+            return getFirst("name");
+        }
+    }
+
+    private static final class GroupUpdate {
+
+        @JsonProperty
+        private final String name;
+        @JsonProperty
+        private final BitBucketPrivilege permission;
+        @JsonProperty(value = "auto_add")
+        private final Boolean autoAdd;
+
+        public GroupUpdate(String nameParam, BitBucketPrivilege permissionParam, Boolean autoAddParam) {
+            this.name = nameParam;
+            this.permission = permissionParam;
+            this.autoAdd = autoAddParam;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public BitBucketPrivilege getPermission() {
+            return permission;
+        }
+
+        public Boolean getAutoAdd() {
+            return autoAdd;
+        }
+    }
+
+}

--- a/src/main/java/org/springframework/social/bitbucket/api/impl/PrivilegeTemplate.java
+++ b/src/main/java/org/springframework/social/bitbucket/api/impl/PrivilegeTemplate.java
@@ -36,25 +36,46 @@ public class PrivilegeTemplate extends AbstractBitBucketOperations implements
     @Override
     public final List<RepoPrivilege> getRepoPrivileges(String user, String repoSlug) {
         return asList(getRestTemplate().getForObject(
-                buildUrl("/privileges/{user}/{repo_slug}"),
+                buildUrl("/privileges/{accountname}/{repo_slug}"),
                 RepoPrivilege[].class, user, repoSlug));
     }
 
     @Override
-    public final RepoPrivilege setPrivilege(String owner, String repoSlug,
-                                            String recipient, BitBucketPrivilege privilege) {
-
-        return getRestTemplate().exchange(
-                buildUrl("/privileges/{user}/{repo_slug}/{recipient}"),
-                HttpMethod.PUT, new HttpEntity<String>(privilege.toString()),
-                RepoPrivilege[].class, owner, repoSlug, recipient).getBody()[0];
+    public final List<RepoPrivilege> getPrivilegesForAnIndividual(String accountName, String repoSlug, String privilegeAccount) {
+        return asList(getRestTemplate().getForObject(
+                buildUrl("/privileges/{accountname}/{repo_slug}"),
+                RepoPrivilege[].class, accountName, repoSlug));
     }
 
     @Override
-    public final void removePrivilege(String owner, String repoSlug, String recipient) {
-        getRestTemplate().delete(
-                buildUrl("/privileges/{user}/{repo_slug}/{recipient}"), owner,
+    public final List<RepoPrivilege> getPrivilegesAcrossAllRepositories(String accountName) {
+        return asList(getRestTemplate().getForObject(buildUrl("/privileges/{accountname}"),
+                RepoPrivilege[].class, accountName));
+    }
+
+    @Override
+    public final RepoPrivilege setPrivilege(String accountName, String repoSlug,
+                                            String recipient, BitBucketPrivilege privilege) {
+        return getRestTemplate().exchange(
+                buildUrl("/privileges/{accountname}/{repo_slug}/{recipient}"),
+                HttpMethod.PUT, new HttpEntity<String>(privilege.toString()),
+                RepoPrivilege[].class, accountName, repoSlug, recipient).getBody()[0];
+    }
+
+    @Override
+    public final void removePrivilege(String accountName, String repoSlug, String recipient) {
+        getRestTemplate().delete(buildUrl("/privileges/{accountname}/{repo_slug}/{recipient}"), accountName,
                 repoSlug, recipient);
+    }
+
+    @Override
+    public final void removeAllPrivilegesFromARepository(String accountName, String repoSlug) {
+        getRestTemplate().delete(buildUrl("/privileges/{accountname}/{repo_slug}"), accountName, repoSlug);
+    }
+
+    @Override
+    public final void removeAllPrivilegesFromAllRepositories(String accountName) {
+        getRestTemplate().delete(buildUrl("/privileges/{accountname}"), accountName);
     }
 
 }

--- a/src/test/java/org/springframework/social/bitbucket/api/impl/GroupsTemplateTest.java
+++ b/src/test/java/org/springframework/social/bitbucket/api/impl/GroupsTemplateTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2012 Eric Bottard / Guillaume Lederrey (eric.bottard+ghpublic@gmail.com / guillaume.lederrey@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.bitbucket.api.impl;
+
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.social.bitbucket.api.BitBucketGroup;
+import org.springframework.social.bitbucket.api.BitBucketPrivilege;
+import org.springframework.social.bitbucket.api.BitBucketUser;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withNoContent;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * @author Cyprian Śniegota
+ * @since 2.0.0
+ */
+public class GroupsTemplateTest extends BaseTemplateTest {
+
+    private static final String TEST_ACCOUNT_NAME = "testaccount";
+    private static final String TEST_GROUP_NAME = "testgroupname";
+    private static final String TEST_GROUP_SLUG = "testgroupslug";
+    private static final String TEST_MEMBER_NAME = "testmembername";
+
+    @Test
+    public void testGetAListOfGroups() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/groups/testaccount")).andExpect(method(GET))
+                .andRespond(withSuccess(jsonResource("get-a-list-of-groups"), MediaType.APPLICATION_JSON));
+        //when
+        List<BitBucketGroup> result = bitBucket.groupsOperations().getAListOfGroups(TEST_ACCOUNT_NAME);
+        //then
+        mockServer.verify();
+        assertEquals(1, result.size());
+        BitBucketGroup firstGroup = result.iterator().next();
+        assertEquals("developers", firstGroup.getName());
+        assertEquals("developers", firstGroup.getSlug());
+        assertEquals(BitBucketPrivilege.read, firstGroup.getPermission());
+        assertEquals(false, firstGroup.isAutoAdd());
+        assertEquals(2, firstGroup.getMembers().size());
+        Iterator<BitBucketUser> membersIterator = firstGroup.getMembers().iterator();
+        BitBucketUser firstMember = membersIterator.next();
+        assertEquals("jstepka", firstMember.getUsername());
+        BitBucketUser secondMember = membersIterator.next();
+        assertEquals("detkin", secondMember.getUsername());
+        assertEquals("baratrion", firstGroup.getOwner().getUsername());
+    }
+
+    @Test
+    public void testPostANewGroup() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/groups/testaccount")).andExpect(method(POST)).andExpect(
+                content().string("name=testgroupname")).andRespond(withSuccess(jsonResource("post-a-new-group"), MediaType.APPLICATION_JSON));
+        //when
+        BitBucketGroup result = bitBucket.groupsOperations().postANewGroup(TEST_ACCOUNT_NAME, TEST_GROUP_NAME);
+        //then
+        mockServer.verify();
+        assertEquals("the designers", result.getName());
+        assertEquals("the-designers", result.getSlug());
+        assertNull(result.getPermission());
+        assertEquals(false, result.isAutoAdd());
+        assertTrue(result.getMembers().isEmpty());
+        assertEquals("2team", result.getOwner().getUsername());
+    }
+
+    @Test
+    public void testUpdateAGroup() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/groups/testaccount/testgroupslug")).andExpect(method(PUT)).andExpect(
+                content().string("{\"name\":\"testgroupname\",\"permission\":\"admin\",\"auto_add\":true}")).andRespond(withSuccess(jsonResource("update-a-group"), MediaType.APPLICATION_JSON));
+        //when
+        BitBucketGroup result = bitBucket.groupsOperations()
+                .updateAGroup(TEST_ACCOUNT_NAME, TEST_GROUP_NAME, TEST_GROUP_SLUG, true, BitBucketPrivilege.admin);
+        //then
+        mockServer.verify();
+        assertEquals("developers", result.getName());
+        assertEquals("developers", result.getSlug());
+        assertEquals(BitBucketPrivilege.write, result.getPermission());
+        assertEquals(true, result.isAutoAdd());
+        assertTrue(result.getMembers().isEmpty());
+        assertEquals("baratrion", result.getOwner().getUsername());
+    }
+
+    @Test
+    public void testRemoveGroup() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/groups/testaccount/testgroupslug"))
+                .andExpect(method(DELETE)).andRespond(withNoContent());
+        //when
+        bitBucket.groupsOperations().removeGroup(TEST_ACCOUNT_NAME, TEST_GROUP_SLUG);
+        //then
+        mockServer.verify();
+    }
+
+    @Test
+    public void testGetTheGroupMembers() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/groups/testaccount/testgroupslug/members")).andExpect(method(GET))
+                .andRespond(withSuccess(jsonResource("get-the-group-members"), MediaType.APPLICATION_JSON));
+        //when
+        List<BitBucketUser> result = bitBucket.groupsOperations().getTheGroupMembers(TEST_ACCOUNT_NAME, TEST_GROUP_SLUG);
+        //then
+        mockServer.verify();
+        assertEquals(2, result.size());
+        Iterator<BitBucketUser> memberIterator = result.iterator();
+        BitBucketUser firstUser = memberIterator.next();
+        BitBucketUser secondUser = memberIterator.next();
+        assertEquals("Justen", firstUser.getFirstName());
+        assertEquals("Etkin", secondUser.getLastName());
+    }
+
+    @Test
+    public void testPutNewMemberIntoAGroup() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/groups/testaccount/testgroupslug/members/testmembername")).andExpect(method(PUT))
+                .andRespond(withSuccess(jsonResource("put-new-member-into-a-group"), MediaType.APPLICATION_JSON));
+        //when
+        BitBucketUser result = bitBucket.groupsOperations().putNewMemberIntoAGroup(TEST_ACCOUNT_NAME, TEST_GROUP_SLUG, TEST_MEMBER_NAME);
+        //then
+        mockServer.verify();
+        assertEquals("atlassian_tutorial", result.getUsername());
+        assertEquals(true, result.isTeam());
+        assertEquals("Atlassian Tutorials", result.getFirstName());
+    }
+
+    @Test
+    public void testRemoveMember() throws Exception {
+        //given
+        mockServer.expect(requestTo("https://api.bitbucket.org/1.0/groups/testaccount/testgroupslug/members/testmembername"))
+                .andExpect(method(DELETE)).andRespond(withNoContent());
+        //when
+        bitBucket.groupsOperations().removeMember(TEST_ACCOUNT_NAME, TEST_GROUP_SLUG, TEST_MEMBER_NAME);
+        //then
+        mockServer.verify();
+    }
+}

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/get-a-list-of-groups.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/get-a-list-of-groups.json
@@ -1,0 +1,31 @@
+[
+  {
+    "name": "developers",
+    "permission": "read",
+    "auto_add": false,
+    "members": [
+      {
+        "username": "jstepka",
+        "first_name": "Justen",
+        "last_name": "Stepka",
+        "avatar": "https://secure.gravatar.com/avatar/12e5043280f67465b68ac42985082498?d=identicon&s=32",
+        "resource_uri": "/1.0/users/jstepka"
+      },
+      {
+        "username": "detkin",
+        "first_name": "Dylan",
+        "last_name": "Etkin",
+        "avatar": "https://secure.gravatar.com/avatar/e1ef8ef737e394a17ffbc27c889c2b22?d=identicon&s=32",
+        "resource_uri": "/1.0/users/detkin"
+      }
+    ],
+    "owner": {
+      "username": "baratrion",
+      "first_name": "Mehmet S",
+      "last_name": "Catalbas",
+      "avatar": "https://secure.gravatar.com/avatar/55a1369161d3a648729b59cabf160e70?d=identicon&s=32",
+      "resource_uri": "/1.0/users/baratrion"
+    },
+    "slug": "developers"
+  }
+]

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/get-privileges-across-all-repositories.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/get-privileges-across-all-repositories.json
@@ -1,0 +1,38 @@
+[
+    {
+        "repo": "evzijst/test",
+        "privilege": "read",
+        "user": {
+            "username": "jespern",
+            "first_name": "Jesper",
+            "last_name": "Noehr"
+        }
+    },
+    {
+        "repo": "evzijst/test",
+        "privilege": "read",
+        "user": {
+            "username": "detkin",
+            "first_name": "Dylan",
+            "last_name": "Etkin"
+        }
+    },
+    {
+        "repo": "evzijst/test",
+        "privilege": "write",
+        "user": {
+            "username": "davidchambers",
+            "first_name": "David",
+            "last_name": "Chambers"
+        }
+    },
+    {
+        "repo": "evzijst/test",
+        "privilege": "admin",
+        "user": {
+            "username": "nvenegas",
+            "first_name": "Nicolas",
+            "last_name": "Venegas"
+        }
+    }
+]

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/get-privileges-for-an-individual.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/get-privileges-for-an-individual.json
@@ -1,0 +1,38 @@
+[
+    {
+        "repo": "evzijst/test",
+        "privilege": "read",
+        "user": {
+            "username": "jespern",
+            "first_name": "Jesper",
+            "last_name": "Noehr"
+        }
+    },
+    {
+        "repo": "evzijst/test",
+        "privilege": "read",
+        "user": {
+            "username": "detkin",
+            "first_name": "Dylan",
+            "last_name": "Etkin"
+        }
+    },
+    {
+        "repo": "evzijst/test",
+        "privilege": "write",
+        "user": {
+            "username": "davidchambers",
+            "first_name": "David",
+            "last_name": "Chambers"
+        }
+    },
+    {
+        "repo": "evzijst/test",
+        "privilege": "admin",
+        "user": {
+            "username": "nvenegas",
+            "first_name": "Nicolas",
+            "last_name": "Venegas"
+        }
+    }
+]

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/get-the-group-members.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/get-the-group-members.json
@@ -1,0 +1,16 @@
+[
+  {
+    "username": "jstepka",
+    "first_name": "Justen",
+    "last_name": "Stepka",
+    "avatar": "https://secure.gravatar.com/avatar/12e5043280f67465b68ac42985082498?d=identicon&s=32",
+    "resource_uri": "/1.0/users/jstepka"
+  },
+  {
+    "username": "detkin",
+    "first_name": "Dylan",
+    "last_name": "Etkin",
+    "avatar": "https://secure.gravatar.com/avatar/e1ef8ef737e394a17ffbc27c889c2b22?d=identicon&s=32",
+    "resource_uri": "/1.0/users/detkin"
+  }
+]

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/post-a-new-group.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/post-a-new-group.json
@@ -1,0 +1,15 @@
+{
+  "name": "the designers",
+  "permission": null,
+  "auto_add": false,
+  "members": [],
+  "owner": {
+    "username": "2team",
+    "first_name": "2 Team",
+    "last_name": "",
+    "is_team": true,
+    "avatar": "https://secure.gravatar.com/avatar/15827007bdb707832ded90a612750cfb?d=https%3A%2F%2Fdwz7u9t8u8usb.cloudfront.net%2Fm%2F90cccbaebb4e%2Fimg%2Fteam_no_avatar_32.png&s=32",
+    "resource_uri": "/1.0/users/2team"
+  },
+  "slug": "the-designers"
+}

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/put-new-member-into-a-group.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/put-new-member-into-a-group.json
@@ -1,0 +1,8 @@
+{
+  "username": "atlassian_tutorial",
+  "first_name": "Atlassian Tutorials",
+  "last_name": "",
+  "is_team": true,
+  "avatar": "https://secure.gravatar.com/avatar/eb4e0ad6934518b3e335345a4ceeef21?d=https%3A%2F%2Fdwz7u9t8u8usb.cloudfront.net%2Fm%2F5441e467b5e2%2Fimg%2Fteam_no_avatar_32.png&s=32",
+  "resource_uri": "/1.0/users/atlassian_tutorial"
+}

--- a/src/test/resources/org/springframework/social/bitbucket/api/impl/update-a-group.json
+++ b/src/test/resources/org/springframework/social/bitbucket/api/impl/update-a-group.json
@@ -1,0 +1,14 @@
+{
+  "name": "developers",
+  "permission": "write",
+  "auto_add": true,
+  "members": [],
+  "owner": {
+    "username": "baratrion",
+    "first_name": "Mehmet S",
+    "last_name": "Catalbas",
+    "avatar": "https://secure.gravatar.com/avatar/55a1369161d3a648729b59cabf160e70?d=identicon&s=32",
+    "resource_uri": "/1.0/users/baratrion"
+  },
+  "slug": "developers"
+}


### PR DESCRIPTION
https://confluence.atlassian.com/display/BITBUCKET/privileges+Endpoint
https://confluence.atlassian.com/display/BITBUCKET/groups+Endpoint without matching group - filtering. Not tested with original BitBucket site.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23issuecomment-112230560%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23issuecomment-112234753%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23issuecomment-112236439%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32474868%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32474985%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32475019%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32475165%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32475517%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32475841%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32475959%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32476241%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32476338%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32476422%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32477045%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32478170%22%2C%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32478172%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23issuecomment-112230560%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good%21%20Thanks%20a%20lot%20for%20the%20help%21%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A40%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20review.%20This%20work%20will%20help%20me%20introducing%20my%20own%20rest%20API%20and%20how%20to%20implement%20spring%20social%20plugin%20for%20other%20API%20I%20would%20like%20to%20use%20in%20the%20future.%22%2C%20%22created_at%22%3A%20%222015-06-15T23%3A10%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11454677%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyprianno%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-15T23%3A24%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20822a18fcd68e2d59685d5cc705a3ed2cacbf8f6d%20src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32474985%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20use%20Lombok%20to%20generate%20the%20getter...%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A35%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20not%20here.%20Interface%20already%20introduces%20methods%20without%20%5C%22get%5C%22.%20It%20will%20break%20applications%20that%20already%20uses%20this%20lib%20in%202.0.0-SNAPSHOT%20version.%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A46%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11454677%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyprianno%22%7D%7D%2C%20%7B%22body%22%3A%20%22Correct%2C%20disregard%20my%20comment%20%28its%20getting%20late%20here%2C%20I%27m%20not%20reading%20carefully%20...%29%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A54%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java%3AL57-68%22%7D%2C%20%22Pull%20822a18fcd68e2d59685d5cc705a3ed2cacbf8f6d%20src/main/java/org/springframework/social/bitbucket/api/impl/GroupsTemplate.java%20113%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32475165%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Lombok%20%3F%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A38%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22done.%22%2C%20%22created_at%22%3A%20%222015-06-15T23%3A04%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11454677%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyprianno%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-15T23%3A24%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/api/impl/GroupsTemplate.java%3AL1-127%22%7D%2C%20%22Pull%20822a18fcd68e2d59685d5cc705a3ed2cacbf8f6d%20src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32475019%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60groupsOperations%60%20should%20probably%20be%20%60final%60%20%28the%20other%20fields%20as%20well...%29%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A36%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20about%20marking%20the%20whole%20class%20as%20final%3F%20Without%20copying%20constructor%27s%20body.%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A47%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11454677%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyprianno%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tend%20to%20dislike%20final%20classes%20unless%20there%20is%20a%20very%20good%20reason%20to%20ensure%20it%20will%20never%20be%20extended.%20Disregard%20the%20comment%20about%20final%20fields%2C%20it%20does%20not%20add%20much%20and%20would%20require%20inlining%20the%20call%20to%20%60initSubApis%28%29%60.%20Probably%20not%20worth%20it.%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A52%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A55%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java%3AL29-37%22%7D%2C%20%22Pull%20822a18fcd68e2d59685d5cc705a3ed2cacbf8f6d%20src/main/java/org/springframework/social/bitbucket/api/BitBucketGroup.java%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/gehel/spring-social-bitbucket/pull/15%23discussion_r32474868%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20added%20a%20dependency%20to%20%5BLombok%5D%28http%3A//jnb.ociweb.com/jnb/jnbJan2010.html%29%2C%20so%20you%20could%20replace%20all%20those%20getters%20with%20%60%40Getter%60.%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A34%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%22%2C%20%22created_at%22%3A%20%222015-06-15T22%3A42%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11454677%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyprianno%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-15T23%3A24%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/org/springframework/social/bitbucket/api/BitBucketGroup.java%3AL1-75%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 822a18fcd68e2d59685d5cc705a3ed2cacbf8f6d src/main/java/org/springframework/social/bitbucket/api/BitBucketGroup.java 51'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/15#discussion_r32474868'>File: src/main/java/org/springframework/social/bitbucket/api/BitBucketGroup.java:L1-75</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I added a dependency to [Lombok](http://jnb.ociweb.com/jnb/jnbJan2010.html), so you could replace all those getters with `@Getter`.
- <a href='https://github.com/cyprianno'><img border=0 src='https://avatars.githubusercontent.com/u/11454677?v=3' height=16 width=16'></a> ok
- [x] <a href='#crh-comment-Pull 822a18fcd68e2d59685d5cc705a3ed2cacbf8f6d src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/15#discussion_r32474985'>File: src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java:L57-68</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Could use Lombok to generate the getter...
- <a href='https://github.com/cyprianno'><img border=0 src='https://avatars.githubusercontent.com/u/11454677?v=3' height=16 width=16'></a> Maybe not here. Interface already introduces methods without "get". It will break applications that already uses this lib in 2.0.0-SNAPSHOT version.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Correct, disregard my comment (its getting late here, I'm not reading carefully ...) :+1:
- [x] <a href='#crh-comment-Pull 822a18fcd68e2d59685d5cc705a3ed2cacbf8f6d src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/15#discussion_r32475019'>File: src/main/java/org/springframework/social/bitbucket/api/impl/BitBucketTemplate.java:L29-37</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `groupsOperations` should probably be `final` (the other fields as well...)
- <a href='https://github.com/cyprianno'><img border=0 src='https://avatars.githubusercontent.com/u/11454677?v=3' height=16 width=16'></a> What about marking the whole class as final? Without copying constructor's body.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I tend to dislike final classes unless there is a very good reason to ensure it will never be extended. Disregard the comment about final fields, it does not add much and would require inlining the call to `initSubApis()`. Probably not worth it.
:+1:
- [x] <a href='#crh-comment-Pull 822a18fcd68e2d59685d5cc705a3ed2cacbf8f6d src/main/java/org/springframework/social/bitbucket/api/impl/GroupsTemplate.java 113'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/15#discussion_r32475165'>File: src/main/java/org/springframework/social/bitbucket/api/impl/GroupsTemplate.java:L1-127</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Lombok ?
- <a href='https://github.com/cyprianno'><img border=0 src='https://avatars.githubusercontent.com/u/11454677?v=3' height=16 width=16'></a> done.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/gehel/spring-social-bitbucket/pull/15#issuecomment-112230560'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looks good! Thanks a lot for the help! :+1:
- <a href='https://github.com/cyprianno'><img border=0 src='https://avatars.githubusercontent.com/u/11454677?v=3' height=16 width=16'></a> Thanks for review. This work will help me introducing my own rest API and how to implement spring social plugin for other API I would like to use in the future.


<a href='https://www.codereviewhub.com/gehel/spring-social-bitbucket/pull/15?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/gehel/spring-social-bitbucket/pull/15?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/gehel/spring-social-bitbucket/pull/15'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>